### PR TITLE
Add current completion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Given a prompt, the model will return one or more predicted completions, and can
 alternative tokens at each position.
 
  ```php
-$complete = $open_ai->complete([
-    'engine' => 'davinci',
+$complete = $open_ai->completion([
+    'model' => 'text-davinci-002',
     'prompt' => 'Hello',
     'temperature' => 0.9,
     'max_tokens' => 150,

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -65,9 +65,8 @@ class OpenAi
      */
     public function completion($opts)
     {
-        $model = $opts['model'] ?? $this->model;
-        $url = Url::completionURL($model);
-        unset($opts['model']);
+        $opts['model'] = $opts['model'] ?? $this->model;
+        $url = Url::completionsURL();
 
         return $this->sendRequest($url, 'POST', $opts);
     }

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -5,6 +5,7 @@ namespace Orhanerday\OpenAi;
 class OpenAi
 {
     private string $engine = "davinci";
+    private string $model = "text-davinci-002";
     private array $headers;
     private array $contentTypes;
 
@@ -45,6 +46,7 @@ class OpenAi
     }
 
     /**
+     * @deprecated
      * @param $opts
      * @return bool|string
      */
@@ -53,6 +55,19 @@ class OpenAi
         $engine = $opts['engine'] ?? $this->engine;
         $url = Url::completionURL($engine);
         unset($opts['engine']);
+
+        return $this->sendRequest($url, 'POST', $opts);
+    }
+
+    /**
+     * @param $opts
+     * @return bool|string
+     */
+    public function completion($opts)
+    {
+        $model = $opts['model'] ?? $this->model;
+        $url = Url::completionURL($model);
+        unset($opts['model']);
 
         return $this->sendRequest($url, 'POST', $opts);
     }

--- a/src/Url.php
+++ b/src/Url.php
@@ -9,12 +9,21 @@ class Url
     public const OPEN_AI_URL = self::ORIGIN . "/" . self::API_VERSION;
 
     /**
+     * @deprecated
      * @param string $engine
      * @return string
      */
     public static function completionURL(string $engine): string
     {
         return self::OPEN_AI_URL . "/engines/$engine/completions";
+    }
+
+    /**
+     * @return string
+     */
+    public static function completionsURL(): string
+    {
+        return self::OPEN_AI_URL . "/completions";
     }
 
     /**

--- a/tests/OpenAiTest.php
+++ b/tests/OpenAiTest.php
@@ -3,6 +3,7 @@
 
 use Orhanerday\OpenAi\OpenAi;
 
+$open_ai = new OpenAi('OPEN-AI-KEY');
 
 it('should handle simple completion using the new endpoint', function () use ($open_ai) {
     $result = $open_ai->completion([

--- a/tests/OpenAiTest.php
+++ b/tests/OpenAiTest.php
@@ -3,10 +3,20 @@
 
 use Orhanerday\OpenAi\OpenAi;
 
-$open_ai = new OpenAi('OPEN-AI-KEY');
 
+it('should handle simple completion using the new endpoint', function () use ($open_ai) {
+    $result = $open_ai->completion([
+        'prompt' => "Hello",
+        'temperature' => 0.9,
+        "max_tokens" => 150,
+        "frequency_penalty" => 0,
+        "presence_penalty" => 0.6,
+    ]);
 
-it('should handle simple completion', function () use ($open_ai) {
+    $this->assertStringContainsString('text', $result);
+})->group('working');
+
+it('should handle simple completion using the deprecated endpoint', function () use ($open_ai) {
     $result = $open_ai->complete([
         'engine' => 'davinci',
         'prompt' => "Hello",


### PR DESCRIPTION
The complete endpoint relying on engines is now deprecated. 

* This PR updates the repo to use the current endpoint and model parameters. 
* I've created a new function `completion` and `completionsUrl` to preserve backward compatibility with exiting uses of `complete` and `completionURL`.

Documentation:

* https://beta.openai.com/docs/api-reference/completions
* https://beta.openai.com/docs/api-reference/engines