### PR TITLE
Ability to set a timeout value in seconds

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -8,6 +8,7 @@ class OpenAi
     private string $model = "text-davinci-002";
     private array $headers;
     private array $contentTypes;
+    private int $timeout = 0;
 
     public function __construct($OPENAI_API_KEY)
     {
@@ -326,6 +327,14 @@ class OpenAi
     }
 
     /**
+     * @param int $timeout
+     */
+    public function setTimeout(int $timeout)
+    {
+        $this->timeout = $timeout;
+    }
+
+    /**
      * @param string $url
      * @param string $method
      * @param array $opts
@@ -346,7 +355,7 @@ class OpenAi
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING => '',
             CURLOPT_MAXREDIRS => 10,
-            CURLOPT_TIMEOUT => 0,
+            CURLOPT_TIMEOUT => $this->timeout,
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_CUSTOMREQUEST => $method,


### PR DESCRIPTION
Hi,

When OpenAI's servers are overloaded, it can be usefull to add a timeout value on the requests we send to them. 

I just added a private $timeout property, and a public setter. Public API is not impacted, as the default value is still 0.

Usage : 

```$client = new OpenAi($api_key);
$client->setTimeout(10); // <-- add this
$client->complete($params);```