### PR TITLE
Make sendRequest throw Exception containing curl_error if response is false

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -548,6 +548,8 @@ class OpenAi
 
         curl_close($curl);
 
+        if (!$response) throw new Exception(curl_error($curl));
+        
         return $response;
     }
 


### PR DESCRIPTION
I ran into an issue where my local SSL certificate was invalid and the CURL request was failing, but the only response I received was "false". This fix simply makes the sendRequest method throw a new Exception containing the curl_error message if the curl response failed. Hopefully this will help others debug their application in the case of similar or other CURL errors.