### PR TITLE
Enhancement: Expose Response Headers and Rate Limit Metrics, Efficiency Logging

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -547,7 +547,7 @@ class OpenAi
             $rateLimitInfo = [
                 'ratelimit-limit-requests' => array_key_exists('x-ratelimit-limit-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-requests'] : 0,
                 'ratelimit-limit-tokens' => array_key_exists('x-ratelimit-limit-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-tokens'] : 0,
-                'ratelimit-limit-remaining-requests' => array_key_exists('x-ratelimit-limit-remaining-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-remaining-requests'] : 0,
+                'ratelimit-remaining-requests' => array_key_exists('x-ratelimit-remaining-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-requests'] : 0,
                 'ratelimit-remaining-tokens' => array_key_exists('x-ratelimit-remaining-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-tokens'] : 0,
                 'ratelimit-reset-requests' => array_key_exists('x-ratelimit-reset-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-requests'] : 0,
                 'ratelimit-reset-tokens' => array_key_exists('x-ratelimit-reset-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-tokens'] : 0,

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -548,9 +548,9 @@ class OpenAi
                 'ratelimit-limit-requests' => array_key_exists('x-ratelimit-limit-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-requests'] : 0,
                 'ratelimit-limit-tokens' => array_key_exists('x-ratelimit-limit-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-tokens'] : 0,
                 'ratelimit-limit-remaining-requests' => array_key_exists('x-ratelimit-limit-remaining-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-remaining-requests'] : 0,
-                'ratelimit-limit-remaining-tokens' => array_key_exists('x-ratelimit-limit-remaining-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-remaining-tokens'] : 0,
-                'ratelimit-limit-reset-requests' => array_key_exists('x-ratelimit-limit-reset-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-reset-requests'] : 0,
-                'ratelimit-limit-reset-tokens' => array_key_exists('x-ratelimit-limit-reset-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-reset-tokens'] : 0,
+                'ratelimit-remaining-tokens' => array_key_exists('x-ratelimit-remaining-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-tokens'] : 0,
+                'ratelimit-reset-requests' => array_key_exists('x-ratelimit-reset-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-requests'] : 0,
+                'ratelimit-reset-tokens' => array_key_exists('x-ratelimit-reset-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-tokens'] : 0,
             ];
 
             $this->setRateLimitInfo($rateLimitInfo);

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -540,8 +540,6 @@ class OpenAi
     private function hydrateRateLimitInfo(): void
     {
         $responseHeaders = $this->getResponseHeaders();
-        error_log('$responseHeaders: ');
-        error_log(print_r($responseHeaders,true));
         if(!empty($responseHeaders))
         {
             $rateLimitInfo = [

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -18,7 +18,7 @@ class OpenAi
     private array $curlInfo = [];
     private array $responseHeaders;
     private array $rateLimitInfo;
-    private int $processingMs;
+    private int $processingMs = 0;
 
     public function __construct($OPENAI_API_KEY)
     {
@@ -543,12 +543,12 @@ class OpenAi
         if(!empty($responseHeaders))
         {
             $rateLimitInfo = [
-                'ratelimit-limit-requests'              => $responseHeaders['x-ratelimit-limit-requests'][0],
-                'ratelimit-limit-tokens'                => $responseHeaders['x-ratelimit-limit-tokens'][0],
-                'ratelimit-limit-remaining-requests'    => $responseHeaders['x-ratelimit-limit-remaining-requests'][0],
-                'ratelimit-limit-remaining-tokens'      => $responseHeaders['x-ratelimit-limit-remaining-tokens'][0],
-                'ratelimit-limit-reset-requests'        => $responseHeaders['x-ratelimit-limit-reset-requests'][0],
-                'ratelimit-limit-reset-tokens'          => $responseHeaders['x-ratelimit-limit-reset-tokens'][0],
+                'ratelimit-limit-requests' => isset($responseHeaders['x-ratelimit-limit-requests']) ? $responseHeaders['x-ratelimit-limit-requests'][0] : 0,
+                'ratelimit-limit-tokens' => isset($responseHeaders['x-ratelimit-limit-tokens']) ? $responseHeaders['x-ratelimit-limit-tokens'][0] : 0,
+                'ratelimit-limit-remaining-requests' => isset($responseHeaders['x-ratelimit-limit-remaining-requests']) ? $responseHeaders['x-ratelimit-limit-remaining-requests'][0] : 0,
+                'ratelimit-limit-remaining-tokens' => isset($responseHeaders['x-ratelimit-limit-remaining-tokens']) ? $responseHeaders['x-ratelimit-limit-remaining-tokens'][0] : 0,
+                'ratelimit-limit-reset-requests' => isset($responseHeaders['x-ratelimit-limit-reset-requests']) ? $responseHeaders['x-ratelimit-limit-reset-requests'][0] : 0,
+                'ratelimit-limit-reset-tokens' => isset($responseHeaders['x-ratelimit-limit-reset-tokens']) ? $responseHeaders['x-ratelimit-limit-reset-tokens'][0] : 0,
             ];
 
             $this->setRateLimitInfo($rateLimitInfo);
@@ -578,7 +578,7 @@ class OpenAi
     private function hydrateProcessingMs(): void
     {
         $responseHeaders = $this->getResponseHeaders();
-        if(!empty($responseHeaders))
+        if(!empty($responseHeaders) && isset($responseHeaders['openai-processing-ms']))
         {
             $processingMs = $responseHeaders['openai-processing-ms'][0];
 

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -580,7 +580,7 @@ class OpenAi
         $responseHeaders = $this->getResponseHeaders();
         if(!empty($responseHeaders))
         {
-            $processingMs = $responseHeaders['openai-processing-ms'];
+            $processingMs = $responseHeaders['openai-processing-ms'][0];
 
             $this->setProcessingMs($processingMs);
         }

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -543,12 +543,12 @@ class OpenAi
         if(!empty($responseHeaders))
         {
             $rateLimitInfo = [
-                'ratelimit-limit-requests' => array_key_exists('x-ratelimit-limit-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-requests'] : 0,
-                'ratelimit-limit-tokens' => array_key_exists('x-ratelimit-limit-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-tokens'] : 0,
-                'ratelimit-remaining-requests' => array_key_exists('x-ratelimit-remaining-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-requests'] : 0,
-                'ratelimit-remaining-tokens' => array_key_exists('x-ratelimit-remaining-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-tokens'] : 0,
-                'ratelimit-reset-requests' => array_key_exists('x-ratelimit-reset-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-requests'] : 0,
-                'ratelimit-reset-tokens' => array_key_exists('x-ratelimit-reset-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-tokens'] : 0,
+                'ratelimit-limit-requests' => array_key_exists('x-ratelimit-limit-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-requests'] : null,
+                'ratelimit-limit-tokens' => array_key_exists('x-ratelimit-limit-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-tokens'] : null,
+                'ratelimit-remaining-requests' => array_key_exists('x-ratelimit-remaining-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-requests'] : null,
+                'ratelimit-remaining-tokens' => array_key_exists('x-ratelimit-remaining-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-remaining-tokens'] : null,
+                'ratelimit-reset-requests' => array_key_exists('x-ratelimit-reset-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-requests'] : null,
+                'ratelimit-reset-tokens' => array_key_exists('x-ratelimit-reset-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-reset-tokens'] : null,
             ];
 
             $this->setRateLimitInfo($rateLimitInfo);

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -543,12 +543,12 @@ class OpenAi
         if(!empty($responseHeaders))
         {
             $rateLimitInfo = [
-                'ratelimit-limit-requests' => isset($responseHeaders['x-ratelimit-limit-requests']) ? $responseHeaders['x-ratelimit-limit-requests'][0] : 0,
-                'ratelimit-limit-tokens' => isset($responseHeaders['x-ratelimit-limit-tokens']) ? $responseHeaders['x-ratelimit-limit-tokens'][0] : 0,
-                'ratelimit-limit-remaining-requests' => isset($responseHeaders['x-ratelimit-limit-remaining-requests']) ? $responseHeaders['x-ratelimit-limit-remaining-requests'][0] : 0,
-                'ratelimit-limit-remaining-tokens' => isset($responseHeaders['x-ratelimit-limit-remaining-tokens']) ? $responseHeaders['x-ratelimit-limit-remaining-tokens'][0] : 0,
-                'ratelimit-limit-reset-requests' => isset($responseHeaders['x-ratelimit-limit-reset-requests']) ? $responseHeaders['x-ratelimit-limit-reset-requests'][0] : 0,
-                'ratelimit-limit-reset-tokens' => isset($responseHeaders['x-ratelimit-limit-reset-tokens']) ? $responseHeaders['x-ratelimit-limit-reset-tokens'][0] : 0,
+                'ratelimit-limit-requests' => array_key_exists('x-ratelimit-limit-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-requests'] : 0,
+                'ratelimit-limit-tokens' => array_key_exists('x-ratelimit-limit-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-tokens'] : 0,
+                'ratelimit-limit-remaining-requests' => array_key_exists('x-ratelimit-limit-remaining-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-remaining-requests'] : 0,
+                'ratelimit-limit-remaining-tokens' => array_key_exists('x-ratelimit-limit-remaining-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-remaining-tokens'] : 0,
+                'ratelimit-limit-reset-requests' => array_key_exists('x-ratelimit-limit-reset-requests',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-reset-requests'] : 0,
+                'ratelimit-limit-reset-tokens' => array_key_exists('x-ratelimit-limit-reset-tokens',$responseHeaders) ? $responseHeaders['x-ratelimit-limit-reset-tokens'] : 0,
             ];
 
             $this->setRateLimitInfo($rateLimitInfo);
@@ -578,9 +578,9 @@ class OpenAi
     private function hydrateProcessingMs(): void
     {
         $responseHeaders = $this->getResponseHeaders();
-        if(!empty($responseHeaders) && isset($responseHeaders['openai-processing-ms']))
+        if(!empty($responseHeaders) && array_key_exists('openai-processing-ms',$responseHeaders))
         {
-            $processingMs = $responseHeaders['openai-processing-ms'][0];
+            $processingMs = $responseHeaders['openai-processing-ms'];
 
             $this->setProcessingMs($processingMs);
         }
@@ -641,10 +641,14 @@ class OpenAi
                     return $len;
 
                 $name = strtolower(trim($header[0]));
-                if (!array_key_exists($name, $responseHeaders))
-                    $responseHeaders[$name] = [trim($header[1])];
-                else
+                if (!array_key_exists($name, $responseHeaders)) {
+                    $responseHeaders[$name] = trim($header[1]);
+                } else {
+                    if (!is_array($responseHeaders[$name])) {
+                        $responseHeaders[$name] = [$responseHeaders[$name]];
+                    }
                     $responseHeaders[$name][] = trim($header[1]);
+                }
 
                 return $len;
             }

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -543,12 +543,12 @@ class OpenAi
         if(!empty($responseHeaders))
         {
             $rateLimitInfo = [
-                'ratelimit-limit-requests'              => $responseHeaders['x-ratelimit-limit-requests'],
-                'ratelimit-limit-tokens'                => $responseHeaders['x-ratelimit-limit-tokens'],
-                'ratelimit-limit-remaining-requests'    => $responseHeaders['x-ratelimit-limit-remaining-requests'],
-                'ratelimit-limit-remaining-tokens'      => $responseHeaders['x-ratelimit-limit-remaining-tokens'],
-                'ratelimit-limit-reset-requests'        => $responseHeaders['x-ratelimit-limit-reset-requests'],
-                'ratelimit-limit-reset-tokens'          => $responseHeaders['x-ratelimit-limit-reset-tokens'],
+                'ratelimit-limit-requests'              => $responseHeaders['x-ratelimit-limit-requests'][0],
+                'ratelimit-limit-tokens'                => $responseHeaders['x-ratelimit-limit-tokens'][0],
+                'ratelimit-limit-remaining-requests'    => $responseHeaders['x-ratelimit-limit-remaining-requests'][0],
+                'ratelimit-limit-remaining-tokens'      => $responseHeaders['x-ratelimit-limit-remaining-tokens'][0],
+                'ratelimit-limit-reset-requests'        => $responseHeaders['x-ratelimit-limit-reset-requests'][0],
+                'ratelimit-limit-reset-tokens'          => $responseHeaders['x-ratelimit-limit-reset-tokens'][0],
             ];
 
             $this->setRateLimitInfo($rateLimitInfo);


### PR DESCRIPTION
This pull request introduces an array of updates aimed at providing greater visibility for response-level information and optimizing processing efficiency. Key enhancement details include the following:

Additions:
setResponseHeaders and getResponseHeaders methods have been implemented to allow the storage of response headers.
setRateLimitInfo, getRateLimitInfo, and hydrateRateLimitInfo methods have been implemented to provide visibility of rate-limiting information.
setProcessingMs, getProcessingMs, and hydrateProcessingMs methods have been implemented to monitor processing time in milliseconds.
setHeaderFunction method has been implemented to manage header formatting and assignment.
Refactoring:
Existing methods have been refactored to accommodate the setHeaderFunction method and to hydrate the rate limiting and processing info after every request.
These changes will assist in monitoring usage, complying with rate-limits, and optimizing processing speed. Further testing and feedback are appreciated.

Commit log:
Provide access to responseHeaders
Add processingMs and cleanup
Cleanup sub-indexing
Implement isset
Fix indexing
Refactor to setHeaderMethod and error_log for test
Fix key values for rate limit headers
Cleanup
Fix default values to avoid confusion

From the OpenAi Docs:
<img width="774" alt="Screenshot 2023-11-14 at 2 25 17 PM" src="https://github.com/orhanerday/open-ai/assets/45575335/66b8ad22-7c15-42a4-8408-e43ecd232835">