### PR TITLE
Support for OpenAI-Beta assistants v2 and streaming.

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -709,8 +709,18 @@ class OpenAi
      * @param array $data
      * @return bool|string
      */
-    public function createRun($threadId, $data)
+    public function createRun($threadId, $data, $stream = null)
     {
+        if (array_key_exists('stream', $data) && $data['stream']) {
+            if ($stream == null) {
+                throw new Exception(
+                    'Please provide a stream function. Check https://github.com/orhanerday/open-ai#stream-example for an example.'
+                );
+            }
+
+            $this->stream_method = $stream;
+        }
+        
         $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs';
         $this->baseUrl($url);
@@ -770,8 +780,18 @@ class OpenAi
      * @param array $outputs
      * @return bool|string
      */
-    public function submitToolOutputs($threadId, $runId, $outputs)
+    public function submitToolOutputs($threadId, $runId, $outputs, $stream = null)
     {
+        if (array_key_exists('stream', $outputs) && $outputs['stream']) {
+            if ($stream == null) {
+                throw new Exception(
+                    'Please provide a stream function. Check https://github.com/orhanerday/open-ai#stream-example for an example.'
+                );
+            }
+
+            $this->stream_method = $stream;
+        }
+        
         $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId . '/submit_tool_outputs';
         $this->baseUrl($url);

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -933,7 +933,7 @@ class OpenAi
     /**
      * @return void
      */
-    public function addAssistantsBetaHeader(){ 
+    private function addAssistantsBetaHeader(){ 
         $this->headers[] = 'OpenAI-Beta: assistants='.$this->assistantsBetaVersion;
     }
     

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -9,6 +9,7 @@ class OpenAi
     private string $engine = "davinci";
     private string $model = "text-davinci-002";
     private string $chatModel = "gpt-3.5-turbo";
+    private string $assistantsBetaVersion = "v1";
     private array $headers;
     private array $contentTypes;
     private int $timeout = 0;
@@ -435,7 +436,7 @@ class OpenAi
     public function createAssistant($data)
     {
         $data['model'] = $data['model'] ?? $this->chatModel;
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl();
         $this->baseUrl($url);
 
@@ -448,7 +449,7 @@ class OpenAi
      */
     public function retrieveAssistant($assistantId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId;
         $this->baseUrl($url);
 
@@ -462,7 +463,7 @@ class OpenAi
      */
     public function modifyAssistant($assistantId, $data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId;
         $this->baseUrl($url);
 
@@ -475,7 +476,7 @@ class OpenAi
      */
     public function deleteAssistant($assistantId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId;
         $this->baseUrl($url);
 
@@ -488,7 +489,7 @@ class OpenAi
      */
     public function listAssistants($query = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl();
         if (count($query) > 0) {
             $url .= '?' . http_build_query($query);
@@ -505,7 +506,7 @@ class OpenAi
      */
     public function createAssistantFile($assistantId, $fileId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId . '/files';
         $this->baseUrl($url);
 
@@ -519,7 +520,7 @@ class OpenAi
      */
     public function retrieveAssistantFile($assistantId, $fileId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId . '/files/' . $fileId;
         $this->baseUrl($url);
 
@@ -533,7 +534,7 @@ class OpenAi
      */
     public function listAssistantFiles($assistantId, $query = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId . '/files';
         if (count($query) > 0) {
             $url .= '?' . http_build_query($query);
@@ -550,7 +551,7 @@ class OpenAi
      */
     public function deleteAssistantFile($assistantId, $fileId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::assistantsUrl() . '/' . $assistantId . '/files/' . $fileId;
         $this->baseUrl($url);
 
@@ -563,7 +564,7 @@ class OpenAi
      */
     public function createThread($data = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl();
         $this->baseUrl($url);
 
@@ -576,7 +577,7 @@ class OpenAi
      */
     public function retrieveThread($threadId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId;
         $this->baseUrl($url);
 
@@ -590,7 +591,7 @@ class OpenAi
      */
     public function modifyThread($threadId, $data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId;
         $this->baseUrl($url);
 
@@ -603,7 +604,7 @@ class OpenAi
      */
     public function deleteThread($threadId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId;
         $this->baseUrl($url);
 
@@ -617,7 +618,7 @@ class OpenAi
      */
     public function createThreadMessage($threadId, $data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/messages';
         $this->baseUrl($url);
 
@@ -631,7 +632,7 @@ class OpenAi
      */
     public function retrieveThreadMessage($threadId, $messageId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/messages/' . $messageId;
         $this->baseUrl($url);
 
@@ -646,7 +647,7 @@ class OpenAi
      */
     public function modifyThreadMessage($threadId, $messageId, $data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/messages/' . $messageId;
         $this->baseUrl($url);
 
@@ -660,7 +661,7 @@ class OpenAi
      */
     public function listThreadMessages($threadId, $query = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/messages';
         if (count($query) > 0) {
             $url .= '?' . http_build_query($query);
@@ -678,7 +679,7 @@ class OpenAi
      */
     public function retrieveMessageFile($threadId, $messageId, $fileId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/messages/' . $messageId . '/files/' . $fileId;
         $this->baseUrl($url);
 
@@ -693,7 +694,7 @@ class OpenAi
      */
     public function listMessageFiles($threadId, $messageId, $query = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/messages/' . $messageId . '/files';
         if (count($query) > 0) {
             $url .= '?' . http_build_query($query);
@@ -710,7 +711,7 @@ class OpenAi
      */
     public function createRun($threadId, $data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs';
         $this->baseUrl($url);
 
@@ -724,7 +725,7 @@ class OpenAi
      */
     public function retrieveRun($threadId, $runId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId;
         $this->baseUrl($url);
 
@@ -739,7 +740,7 @@ class OpenAi
      */
     public function modifyRun($threadId, $runId, $data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId;
         $this->baseUrl($url);
 
@@ -753,7 +754,7 @@ class OpenAi
      */
     public function listRuns($threadId, $query = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs';
         if (count($query) > 0) {
             $url .= '?' . http_build_query($query);
@@ -771,7 +772,7 @@ class OpenAi
      */
     public function submitToolOutputs($threadId, $runId, $outputs)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId . '/submit_tool_outputs';
         $this->baseUrl($url);
 
@@ -785,7 +786,7 @@ class OpenAi
      */
     public function cancelRun($threadId, $runId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId . '/cancel';
         $this->baseUrl($url);
 
@@ -798,7 +799,7 @@ class OpenAi
      */
     public function createThreadAndRun($data)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/runs';
         $this->baseUrl($url);
 
@@ -813,7 +814,7 @@ class OpenAi
      */
     public function retrieveRunStep($threadId, $runId, $stepId)
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId . '/steps/' . $stepId;
         $this->baseUrl($url);
 
@@ -828,7 +829,7 @@ class OpenAi
      */
     public function listRunSteps($threadId, $runId, $query = [])
     {
-        $this->headers[] = 'OpenAI-Beta: assistants=v1';
+        $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId . '/steps';
         if (count($query) > 0) {
             $url .= '?' . http_build_query($query);
@@ -918,6 +919,24 @@ class OpenAi
             $this->headers[] = "OpenAI-Organization: $org";
         }
     }
+    
+    /**
+     * @param  string  $org
+     */
+    public function setAssistantsBetaVersion(string $version)
+    {
+        if ($version != "") {
+            $this->assistantsBetaVersion = $version;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function addAssistantsBetaHeader(){ 
+        $this->headers[] = 'OpenAI-Beta: assistants='.$this->assistantsBetaVersion;
+    }
+    
 
     /**
      * @param  string  $url


### PR DESCRIPTION
Ability to set OpenAI assistants beta header:
- v1 is still supported by OpenAI, so it is kept as default (no BC break)
- version can be set by calling `->setAssistantsBetaVersion("v2")`

Stream option is added to the following methods:
- `createRun($threadId, $data, $stream = null)`
- `submitToolOutputs($threadId, $runId, $outputs, $stream = null)`
- stream callback usage is the same as with `chat()` method