### PR TITLE
curl_error must be called before curl_close

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -1003,6 +1003,7 @@ class OpenAi
 
         curl_setopt_array($curl, $curl_info);
         $response = curl_exec($curl);
+        $curl_error = curl_error($curl);
 
         $info = curl_getinfo($curl);
         $this->curlInfo = $info;
@@ -1010,7 +1011,7 @@ class OpenAi
         curl_close($curl);
 
         if (! $response) {
-            throw new Exception(curl_error($curl));
+            throw new Exception($curl_error);
         }
 
         return $response;


### PR DESCRIPTION
curl_error can't fetch error info from closed curl session.
First comment https://www.php.net/manual/en/function.curl-error.php
https://stackoverflow.com/questions/19442999/getting-curl-error-2-is-not-a-valid-curl-handle-resource-while-fetching-all-u