### PR TITLE
The OpenAI-Project header can be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,16 +311,17 @@ use Orhanerday\OpenAi\OpenAi;
 $open_ai = new OpenAi(env('OPEN_AI_API_KEY'));
 ```
 
-## Requesting organization
+## Requesting organization, project (optional)
 
-For users who belong to multiple organizations, you can pass a header to specify which organization is used for an API
+For users who belong to multiple organizations, projects, you can pass a header to specify which organization, project is used for an API
 request.
 Usage from these API requests will count against the specified organization's subscription quota.
 
 ````php
 $open_ai_key = getenv('OPENAI_API_KEY');
 $open_ai = new OpenAi($open_ai_key);
-$open_ai->setORG("org-IKN2E1nI3kFYU8ywaqgFRKqi");
+$open_ai->setORG('<YOUR-ORG-ID>');
+$open_ai->setProject('<YOUR-PROJECT-ID>');
 ````
 
 ## Base URL

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -939,7 +939,17 @@ class OpenAi
             $this->headers[] = "OpenAI-Organization: $org";
         }
     }
-    
+
+    /**
+     * @param  string  $project
+     */
+    public function setProject(string $project)
+    {
+        if ($project != "") {
+            $this->headers[] = "OpenAI-Project: $project";
+        }
+    }
+
     /**
      * @param  string  $org
      */


### PR DESCRIPTION
Documentation: https://platform.openai.com/docs/api-reference/organizations-and-projects-optional

```shell
curl https://api.openai.com/v1/models \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "OpenAI-Organization: org-lEOCXdqO48RKaa66ZdhPseo7" \
  -H "OpenAI-Project: $PROJECT_ID"
    ^^^^^^^^^^^^^^^^^^
```

If we are working on several projects, you can specify which of the given requests belong to:
```php
$open_ai_key = getenv('OPENAI_API_KEY');
$open_ai = new OpenAi($open_ai_key);
$open_ai->setProject('<YOUR-PROJECT-ID>'); // `proj_XXX`
```