### PR TITLE
Add vector store apis for assistants

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -903,13 +903,13 @@ class OpenAi
 
     /**
      * Perform a file upload for each curl file in the files array, then attach them to the given vector store.
-     * Poll the file batch every 3s until it is completed, then return the file batch.
+     * Poll the file batch every 3s until it is completed, then return the file batch and openai file object ids.
      * @param string $vectorStoreId
      * @param CURLFile[] $files
-     * @return bool|string
+     * @return array{fileIds: array, fileBatch: bool|string}
      * @throws Exception
      */
-    public function uploadFilesToVectorStoreAndPoll(string $vectorStoreId, array $files)
+    public function uploadFilesToVectorStoreAndPoll(string $vectorStoreId, array $files): array
     {
         $fileIds = [];
         foreach ($files as $file) {
@@ -935,7 +935,7 @@ class OpenAi
                 case 'failed':
                     throw new Exception('File batch failed');
                 case 'completed':
-                    return $fileBatch;
+                    return ['fileIds' => $fileIds, 'fileBatch' => $fileBatch];
             }
 
             sleep(3);

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -902,6 +902,21 @@ class OpenAi
     }
 
     /**
+     * @param string $vectorStoreId
+     * @param string $fileId
+     * @return bool|string
+     * @throws Exception
+     */
+    public function createVectorStoreFile(string $vectorStoreId, string $fileId)
+    {
+        $this->addAssistantsBetaHeader();
+        $url = Url::vectorStoreUrl() . '/' . $vectorStoreId . '/files';
+        $this->baseUrl($url);
+
+        return $this->sendRequest($url, 'POST', ['file_id' => $fileId]);
+    }
+
+    /**
      * Perform a file upload for each curl file in the files array, then attach them to the given vector store.
      * Poll the file batch every 3s until it is completed, then return the file batch and openai file object ids.
      * @param string $vectorStoreId

--- a/src/Url.php
+++ b/src/Url.php
@@ -187,4 +187,9 @@ class Url
     {
         return self::OPEN_AI_URL . "/audio/speech";
     }
+
+    public static function vectorStoreUrl(): string
+    {
+        return self::OPEN_AI_URL . "/vector_stores";
+    }
 }


### PR DESCRIPTION
# Changes

Add functions to create and read vector stores and vector store file batches. Add a separate helper function to handle uploading files, then associating them with the vector store. 

The helper function to upload and poll was more for my personal needs, so can remove it for this PR if it is not something you want to include in the lib.

I have also updated the assistants beta version to v2 by default - can also remove this if needed.

# Rationale

The lib has functions for most of the assistants endpoints, but not for the vector store apis. These are required for building a RAG app using the assistants apis, so i've added them.

Please let me know if you need any other changes to accept this PR, happy to do whatever to get it across the line.

Thanks for the lib, its nice to have something for < php8 out there

