### PR TITLE
Add `setApiKey` method

### DIFF
--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -720,7 +720,7 @@ class OpenAi
 
             $this->stream_method = $stream;
         }
-        
+
         $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs';
         $this->baseUrl($url);
@@ -791,7 +791,7 @@ class OpenAi
 
             $this->stream_method = $stream;
         }
-        
+
         $this->addAssistantsBetaHeader();
         $url = Url::threadsUrl() . '/' . $threadId . '/runs/' . $runId . '/submit_tool_outputs';
         $this->baseUrl($url);
@@ -965,10 +965,10 @@ class OpenAi
     /**
      * @return void
      */
-    private function addAssistantsBetaHeader(){ 
+    private function addAssistantsBetaHeader()
+    {
         $this->headers[] = 'OpenAI-Beta: assistants='.$this->assistantsBetaVersion;
     }
-    
 
     /**
      * @param  string  $url

--- a/src/OpenAi.php
+++ b/src/OpenAi.php
@@ -18,7 +18,7 @@ class OpenAi
     private string $proxy = "";
     private array $curlInfo = [];
 
-    public function __construct($OPENAI_API_KEY)
+    public function __construct($OPENAI_API_KEY = '')
     {
         $this->contentTypes = [
             "application/json" => "Content-Type: application/json",
@@ -939,7 +939,19 @@ class OpenAi
             $this->headers[] = "OpenAI-Organization: $org";
         }
     }
-    
+
+    /**
+     * @param string $token
+     */
+    public function setApiKey(string $token)
+    {
+        if ($token != "") {
+            $this->headers[1] = "Authorization: Bearer $token";
+        }
+
+        return $this;
+    }
+
     /**
      * @param  string  $org
      */
@@ -967,6 +979,12 @@ class OpenAi
     private function sendRequest(string $url, string $method, array $opts = [])
     {
         $post_fields = json_encode($opts);
+
+        if ($this->headers[1] === 'Authorization: Bearer ') {
+            throw new Exception(
+                'Please provide an API key.'
+            );
+        }
 
         if (array_key_exists('file', $opts) || array_key_exists('image', $opts)) {
             $this->headers[0] = $this->contentTypes["multipart/form-data"];

--- a/tests/OpenAiTest.php
+++ b/tests/OpenAiTest.php
@@ -618,8 +618,22 @@ it('should throw error when API key is not set', function () use ($open_ai_with_
 
 $open_ai_with_set_api_key = (new OpenAi())->setApiKey(getenv('OPENAI_API_KEY'));
 
-it('should handle simple completion with API key set', function () use ($open_ai_with_set_api_key) {
+it('should handle simple completion with new setApiKey method', function () use ($open_ai_with_set_api_key) {
     $result = $open_ai_with_set_api_key->completion([
+        'prompt' => "Hello",
+        'temperature' => 0.9,
+        "max_tokens" => 150,
+        "frequency_penalty" => 0,
+        "presence_penalty" => 0.6,
+    ]);
+
+    $this->assertStringContainsString('text', $result);
+})->group('api-keys');
+
+$open_ai_backward_compatible = (new OpenAi(getenv('OPENAI_API_KEY')));
+
+it('should handle simple completion in backward compatible manner', function () use ($open_ai_backward_compatible) {
+    $result = $open_ai_backward_compatible->completion([
         'prompt' => "Hello",
         'temperature' => 0.9,
         "max_tokens" => 150,

--- a/tests/OpenAiTest.php
+++ b/tests/OpenAiTest.php
@@ -603,3 +603,29 @@ it('should handle list run steps', function () use ($open_ai) {
     $this->assertStringContainsString('"object": "list"', $steps);
     $this->assertStringContainsString('data', $steps);
 })->group('working');
+
+$open_ai_with_unset_api_key = new OpenAi();
+
+it('should throw error when API key is not set', function () use ($open_ai_with_unset_api_key) {
+    expect(fn () => $open_ai_with_unset_api_key->completion([
+        'prompt' => "Hello",
+        'temperature' => 0.9,
+        "max_tokens" => 150,
+        "frequency_penalty" => 0,
+        "presence_penalty" => 0.6,
+    ]))->toThrow(Exception::class, 'Please provide an API key.');
+})->group('api-keys');
+
+$open_ai_with_set_api_key = (new OpenAi())->setApiKey(getenv('OPENAI_API_KEY'));
+
+it('should handle simple completion with API key set', function () use ($open_ai_with_set_api_key) {
+    $result = $open_ai_with_set_api_key->completion([
+        'prompt' => "Hello",
+        'temperature' => 0.9,
+        "max_tokens" => 150,
+        "frequency_penalty" => 0,
+        "presence_penalty" => 0.6,
+    ]);
+
+    $this->assertStringContainsString('text', $result);
+})->group('api-keys');


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/orhanerday/open-ai/issues/156).

## Description / Background Context

At the moment, **it is difficult to effectively mock our OpenAi class in unit tests** because we are currently **forced to pass in the API key as an argument during instantiation**.

This PR creates a new `setApiKey` method that enables us do this anytime so that we are not restricted to the constructor. In this way, we can create and pass our objects via dependency injection like so:

```php
interface AiClient
{
    public function chat($payload): void;
}

public function getAiClient(AiClient $aiClient)
{
    return $aiClient;
}

public function getOpenAiClient()
{
    $this->getAiClient(new OpenAi())->setApiKey($keys);
}
```

In this way, we should be able to easily mock our OpenAi class for use in unit tests like so:

```php
public function testOpenAiDoesSomething()
{
    $openAiMock = Mockery::mock(OpenAi::class)->makePartial();
    // write your other test logic....
}
```

## Testing Instructions

1. Pull PR to local.
2. Run `composer install`.
3. Run unit tests: `./vendor/bin/pest --group=api-keys`
4. Tests should pass successfully like so:

<img width="747" alt="Screenshot 2025-03-07 at 19 19 44" src="https://github.com/user-attachments/assets/e1330900-310b-4ec1-a2ee-4e6ded1ab1b4" />

### Closes: #156 